### PR TITLE
feat: RedocによるOpenAPIドキュメント表示のセットアップ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# OS Generated Files
+.DS_Store
+Thumbs.db
+
+# Node.js and npm
+node_modules
+package-lock.json
+yarn.lock
+
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+temp/
+
+# IDE specific files
+.idea/
+.vscode/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Health Management API</title>
+  </head>
+  <body>
+    <redoc spec-url="/openapi.yaml"></redoc>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  </body>
+</html>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,76 @@
+openapi: 3.0.0
+info:
+  title: Health Management API
+  version: v1
+  description: 健康管理に関するAPIです。
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+servers:
+  - url: http://localhost:8080/api/v1 # APIのベースURL
+paths:
+  /users:
+    get:
+      summary: ユーザーの一覧を取得します。
+      responses:
+        "200":
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      format: int64
+                    name:
+                      type: string
+                    email:
+                      type: string
+                      format: email
+    post:
+      summary: 新しいユーザーを作成します。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                  format: email
+      responses:
+        "201":
+          description: 作成成功
+        "400":
+          description: 無効なリクエスト
+  /health-data:
+    post:
+      summary: 健康データを登録します。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: integer
+                  format: int64
+                timestamp:
+                  type: string
+                  format: date-time
+                heartRate:
+                  type: integer
+                steps:
+                  type: integer
+      responses:
+        "201":
+          description: 登録成功
+        "400":
+          description: 無効なリクエスト


### PR DESCRIPTION
## 概要

RedocによるOpenAPIドキュメント表示のセットアップ

## 背景

health-management-appのAPIs時要所を作成するために必要になったため

## 主な変更点

- CDNでRedocを読み込みHTMLを作成
- 仮のopenapi.yamlを作成

## テスト方法

ブラウザでindex.htmlを開きopenapi.yamlの内容が表示されることを確認

## 関連Issue

- Issue #1

## スクリーンショット (UIの変更がある場合)

![health-management-api-openapi_issue1-1](https://github.com/user-attachments/assets/9958a760-74ed-4c47-a6f3-0eaa0da168b2)

## その他

openapi.yamlの内容は完全に仮のものなのでセットアップと画面に表示されていることを確認いただければ問題ないです。
